### PR TITLE
Add Gunicorn dependency for deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask==3.0.2
+gunicorn==23.0.0


### PR DESCRIPTION
## Summary
- add Gunicorn alongside Flask so deployments install the WSGI server

## Testing
- pip install -r requirements.txt *(fails: proxy returns 403 Forbidden while downloading packages)*
- gunicorn app:app *(fails: command not found because Gunicorn could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe7db3fc88331b1316bf026e3846a