### PR TITLE
Surface lithology tables from workbook

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,26 +3,206 @@ from __future__ import annotations
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import List, TypedDict
+from typing import Dict, List, TypedDict
+from zipfile import ZipFile
+
+import xml.etree.ElementTree as ET
 
 from flask import Flask, abort, jsonify, render_template, send_from_directory
 
 BASE_DIR = Path(__file__).resolve().parent
 DATA_FILE = BASE_DIR / "data" / "lithology_entries.json"
 PDF_DIRECTORY = BASE_DIR
+EXCEL_FILE = BASE_DIR / "Geological Profiles.xlsx"
+
+XML_NAMESPACES = {
+    "main": "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+    "rel": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+}
 
 
-class LithologyEntry(TypedDict):
+class LithologySection(TypedDict):
+    from_depth: str
+    to_depth: str
+    description: str
+
+
+class LithologyEntryBase(TypedDict):
     tab_name: str
     title: str
     description: str
     pdf_filename: str
 
 
+class LithologyEntry(LithologyEntryBase, total=False):
+    sections: List[LithologySection]
+
+
+def _read_shared_strings(zf: ZipFile) -> List[str]:
+    try:
+        raw = zf.read("xl/sharedStrings.xml")
+    except KeyError:
+        return []
+
+    root = ET.fromstring(raw)
+    strings: List[str] = []
+    for item in root.findall("main:si", XML_NAMESPACES):
+        text = "".join(
+            node.text or "" for node in item.findall(".//main:t", XML_NAMESPACES)
+        )
+        strings.append(text)
+    return strings
+
+
+def _cell_value(cell: ET.Element, shared_strings: List[str]) -> str:
+    value_element = cell.find("main:v", XML_NAMESPACES)
+    if value_element is None or value_element.text is None:
+        return ""
+
+    cell_type = cell.attrib.get("t")
+    if cell_type == "s":
+        try:
+            index = int(value_element.text)
+        except ValueError:
+            return ""
+        if 0 <= index < len(shared_strings):
+            return shared_strings[index]
+        return ""
+
+    return value_element.text
+
+
+def _column_from_reference(reference: str) -> str:
+    return "".join(char for char in reference if char.isalpha())
+
+
+def _format_numeric(value: str) -> str:
+    text = value.strip()
+    if not text:
+        return ""
+
+    try:
+        number = float(text)
+    except ValueError:
+        return text
+
+    if number.is_integer():
+        return f"{int(number)}"
+
+    formatted = f"{number:.2f}".rstrip("0").rstrip(".")
+    return formatted or text
+
+
+def _parse_sheet_sections(
+    sheet_data: ET.Element, shared_strings: List[str]
+) -> List[LithologySection]:
+    sections: List[LithologySection] = []
+    rows = sheet_data.findall("main:row", XML_NAMESPACES)
+    for index, row in enumerate(rows):
+        cells: Dict[str, str] = {}
+        for cell in row.findall("main:c", XML_NAMESPACES):
+            reference = cell.attrib.get("r", "")
+            column = _column_from_reference(reference)
+            if not column:
+                continue
+            cells[column] = _cell_value(cell, shared_strings)
+
+        if index == 0:
+            # Skip header row.
+            continue
+
+        start = cells.get("A", "")
+        end = cells.get("B", "")
+        description = cells.get("C", "").strip()
+
+        if not description:
+            continue
+
+        sections.append(
+            LithologySection(
+                from_depth=_format_numeric(start),
+                to_depth=_format_numeric(end),
+                description=description,
+            )
+        )
+
+    return sections
+
+
+@lru_cache(maxsize=1)
+def load_section_tables() -> Dict[str, List[LithologySection]]:
+    if not EXCEL_FILE.exists():
+        return {}
+
+    tables: Dict[str, List[LithologySection]] = {}
+
+    with ZipFile(EXCEL_FILE) as workbook:
+        shared_strings = _read_shared_strings(workbook)
+        workbook_xml = ET.fromstring(workbook.read("xl/workbook.xml"))
+        rels_xml = ET.fromstring(workbook.read("xl/_rels/workbook.xml.rels"))
+
+        relationship_targets = {
+            rel.attrib["Id"]: rel.attrib["Target"] for rel in rels_xml
+        }
+
+        sheets = workbook_xml.findall("main:sheets/main:sheet", XML_NAMESPACES)
+        for sheet in sheets:
+            sheet_name = sheet.attrib.get("name", "").strip()
+            relationship_id = sheet.attrib.get(
+                "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}id"
+            )
+            if not sheet_name or not relationship_id:
+                continue
+
+            sheet_target = relationship_targets.get(relationship_id)
+            if not sheet_target:
+                continue
+
+            sheet_path = f"xl/{sheet_target}"
+            try:
+                sheet_xml = ET.fromstring(workbook.read(sheet_path))
+            except KeyError:
+                continue
+
+            sheet_data = sheet_xml.find("main:sheetData", XML_NAMESPACES)
+            if sheet_data is None:
+                continue
+
+            sections = _parse_sheet_sections(sheet_data, shared_strings)
+            if not sections:
+                continue
+
+            key_candidates = {sheet_name}
+            if not sheet_name.lower().endswith(".pdf"):
+                key_candidates.add(f"{sheet_name}.pdf")
+
+            for key in key_candidates:
+                tables[key] = sections
+
+    return tables
+
+
 @lru_cache(maxsize=1)
 def load_entries() -> List[LithologyEntry]:
     with DATA_FILE.open("r", encoding="utf-8") as fp:
-        data = json.load(fp)
+        data: List[LithologyEntry] = json.load(fp)
+
+    section_tables = load_section_tables()
+    for entry in data:
+        pdf_key = entry.get("pdf_filename", "")
+        sections = section_tables.get(pdf_key)
+        if sections is None:
+            # Fall back to the tab name if the PDF name is not present.
+            sections = section_tables.get(entry.get("tab_name", ""), [])
+        entry["sections"] = [
+            LithologySection(
+                from_depth=section["from_depth"],
+                to_depth=section["to_depth"],
+                description=section["description"],
+            )
+            for section in sections
+        ]
+
     return data
 
 

--- a/static/app.js
+++ b/static/app.js
@@ -1,22 +1,122 @@
 const statusElement = document.getElementById('status');
-const tableWrapper = document.querySelector('.table-wrapper');
-const tableBody = document.querySelector('#lithology-table tbody');
+const entriesContainer = document.getElementById('entries');
 
-function createLinkCell(entry) {
-  const cell = document.createElement('td');
-  const link = document.createElement('a');
-  link.href = `/pdfs/${encodeURIComponent(entry.pdf_filename)}`;
-  link.textContent = 'View PDF';
-  link.target = '_blank';
-  link.rel = 'noopener noreferrer';
-  cell.appendChild(link);
-  return cell;
+function formatDepth(value) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+
+  const text = String(value).trim();
+  if (!text) {
+    return '—';
+  }
+
+  const numericValue = Number(text);
+  if (Number.isFinite(numericValue)) {
+    const rounded = Number.isInteger(numericValue)
+      ? numericValue.toString()
+      : Number(numericValue.toFixed(2)).toString();
+    return `${rounded} m`;
+  }
+
+  return text;
 }
 
-function createTextCell(text) {
-  const cell = document.createElement('td');
-  cell.textContent = text;
-  return cell;
+function createSectionTable(sections) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'section-table__wrapper';
+
+  const table = document.createElement('table');
+  table.className = 'section-table';
+
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  ['From (m)', 'To (m)', 'Description'].forEach((label) => {
+    const th = document.createElement('th');
+    th.scope = 'col';
+    th.textContent = label;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+
+  const tbody = document.createElement('tbody');
+  if (!sections.length) {
+    const emptyRow = document.createElement('tr');
+    const emptyCell = document.createElement('td');
+    emptyCell.colSpan = 3;
+    emptyCell.className = 'section-table__empty';
+    emptyCell.textContent = 'No lithological section data is available in the workbook.';
+    emptyRow.appendChild(emptyCell);
+    tbody.appendChild(emptyRow);
+  } else {
+    sections.forEach((section) => {
+      const row = document.createElement('tr');
+
+      const fromCell = document.createElement('td');
+      fromCell.textContent = formatDepth(section.from_depth);
+      row.appendChild(fromCell);
+
+      const toCell = document.createElement('td');
+      toCell.textContent = formatDepth(section.to_depth);
+      row.appendChild(toCell);
+
+      const descriptionCell = document.createElement('td');
+      descriptionCell.textContent = section.description;
+      row.appendChild(descriptionCell);
+
+      tbody.appendChild(row);
+    });
+  }
+
+  table.appendChild(thead);
+  table.appendChild(tbody);
+  wrapper.appendChild(table);
+
+  return wrapper;
+}
+
+function createEntryCard(entry) {
+  const card = document.createElement('article');
+  card.className = 'entry-card';
+
+  const header = document.createElement('div');
+  header.className = 'entry-card__header';
+
+  const title = document.createElement('h2');
+  title.className = 'entry-card__title';
+  title.textContent = entry.title;
+  header.appendChild(title);
+
+  const badge = document.createElement('span');
+  badge.className = 'entry-card__badge';
+  badge.textContent = entry.tab_name;
+  header.appendChild(badge);
+
+  const description = document.createElement('p');
+  description.className = 'entry-card__description';
+  description.textContent = entry.description;
+
+  const link = document.createElement('a');
+  link.className = 'entry-card__link';
+  link.href = `/pdfs/${encodeURIComponent(entry.pdf_filename)}`;
+  link.textContent = 'Open PDF';
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+
+  const tableTitle = document.createElement('h3');
+  tableTitle.className = 'section-table__title';
+  tableTitle.textContent = 'Lithological Sections';
+
+  const sections = Array.isArray(entry.sections) ? entry.sections : [];
+  const table = createSectionTable(sections);
+
+  card.appendChild(header);
+  card.appendChild(description);
+  card.appendChild(link);
+  card.appendChild(tableTitle);
+  card.appendChild(table);
+
+  return card;
 }
 
 async function loadLithology() {
@@ -28,25 +128,36 @@ async function loadLithology() {
 
     const entries = await response.json();
     if (!Array.isArray(entries) || entries.length === 0) {
+      statusElement.classList.remove('success', 'error');
       statusElement.textContent = 'No lithology sections are available yet.';
       statusElement.classList.add('empty');
+      entriesContainer.hidden = true;
       return;
     }
 
-    tableBody.innerHTML = '';
+    statusElement.classList.remove('empty', 'error', 'success');
+
+    entriesContainer.innerHTML = '';
     entries.forEach((entry) => {
-      const row = document.createElement('tr');
-      row.appendChild(createTextCell(entry.tab_name));
-      row.appendChild(createTextCell(entry.title));
-      row.appendChild(createTextCell(entry.description));
-      row.appendChild(createLinkCell(entry));
-      tableBody.appendChild(row);
+      const card = createEntryCard(entry);
+      entriesContainer.appendChild(card);
     });
 
-    statusElement.textContent = `${entries.length} lithology section${entries.length === 1 ? '' : 's'} loaded.`;
+    const sectionsWithData = entries.filter(
+      (entry) => Array.isArray(entry.sections) && entry.sections.length > 0,
+    ).length;
+
+    const pdfLabel = entries.length === 1 ? 'PDF' : 'PDFs';
+    const tableLabel =
+      sectionsWithData === 1
+        ? 'lithological section table'
+        : 'lithological section tables';
+
+    statusElement.textContent = `${entries.length} ${pdfLabel} loaded with ${sectionsWithData} ${tableLabel}.`;
     statusElement.classList.add('success');
-    tableWrapper.hidden = false;
+    entriesContainer.hidden = false;
   } catch (error) {
+    statusElement.classList.remove('success', 'empty');
     statusElement.textContent = `Error loading lithology sections: ${error.message}`;
     statusElement.classList.add('error');
   }

--- a/static/styles.css
+++ b/static/styles.css
@@ -9,6 +9,7 @@
 
 body {
   margin: 0;
+  background-color: inherit;
 }
 
 main.container {
@@ -28,10 +29,10 @@ header {
 
 .status {
   padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
+  border-radius: 0.75rem;
   background-color: #e4e7eb;
   color: #334155;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.75rem;
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 
@@ -50,53 +51,145 @@ header {
   color: #831843;
 }
 
-.table-wrapper {
+.entries {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.entries[hidden] {
+  display: none;
+}
+
+.entry-card {
+  background-color: #ffffff;
+  border-radius: 0.9rem;
+  padding: 1.5rem;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.entry-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.entry-card__title {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #111827;
+}
+
+.entry-card__badge {
+  background-color: #1f2937;
+  color: #f9fafb;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.entry-card__description {
+  margin: 0;
+  color: #4b5563;
+}
+
+.entry-card__link {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.entry-card__link::after {
+  content: '↗';
+  font-size: 0.9em;
+}
+
+.entry-card__link:hover,
+.entry-card__link:focus {
+  text-decoration: underline;
+}
+
+.section-table__title {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #1f2937;
+}
+
+.section-table__wrapper {
   overflow-x: auto;
-}
-
-#lithology-table {
-  width: 100%;
-  border-collapse: collapse;
-  background-color: #fff;
   border-radius: 0.75rem;
-  overflow: hidden;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  background-color: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
 }
 
-#lithology-table thead {
+.section-table {
+  width: 100%;
+  min-width: 360px;
+  border-collapse: collapse;
+}
+
+.section-table thead {
   background-color: #1f2937;
   color: #f9fafb;
 }
 
-#lithology-table th,
-#lithology-table td {
-  padding: 0.85rem 1rem;
+.section-table th,
+.section-table td {
+  padding: 0.75rem 1rem;
   text-align: left;
 }
 
-#lithology-table tbody tr:nth-child(even) {
-  background-color: #f8fafc;
+.section-table td:nth-child(1),
+.section-table td:nth-child(2) {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
-#lithology-table tbody tr:hover {
-  background-color: #e0f2fe;
+.section-table tbody tr:nth-child(even) {
+  background-color: rgba(148, 163, 184, 0.18);
 }
 
-#lithology-table a {
-  color: #1d4ed8;
-  text-decoration: none;
-  font-weight: 600;
+.section-table__empty {
+  text-align: center;
+  font-style: italic;
+  color: #64748b;
 }
 
-#lithology-table a:hover,
-#lithology-table a:focus {
-  text-decoration: underline;
+@media (max-width: 720px) {
+  main.container {
+    margin: 1.5rem auto;
+    padding: 0 1rem 2.5rem;
+  }
+
+  .entry-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .entry-card__title {
+    font-size: 1.35rem;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     background-color: #0f172a;
     color: #f8fafc;
+  }
+
+  body {
+    background-color: #0f172a;
+    color: #e2e8f0;
   }
 
   .lead {
@@ -108,21 +201,71 @@ header {
     color: #e2e8f0;
   }
 
-  #lithology-table {
-    background-color: #1e293b;
+  .status.success {
+    background-color: #1f6feb;
+    color: #e0f2fe;
   }
 
-  #lithology-table thead {
+  .status.error {
+    background-color: #7f1d1d;
+    color: #fee2e2;
+  }
+
+  .status.empty {
+    background-color: #831843;
+    color: #fde2ff;
+  }
+
+  .entry-card {
+    background-color: #1e293b;
+    box-shadow: 0 18px 36px rgba(2, 6, 23, 0.65);
+  }
+
+  .entry-card__title {
+    color: #f8fafc;
+  }
+
+  .entry-card__badge {
+    background-color: #0f172a;
+    color: #f8fafc;
+  }
+
+  .entry-card__description {
+    color: #cbd5f5;
+  }
+
+  .entry-card__link {
+    color: #93c5fd;
+  }
+
+  .entry-card__link:hover,
+  .entry-card__link:focus {
+    color: #bfdbfe;
+  }
+
+  .section-table__title {
+    color: #f8fafc;
+  }
+
+  .section-table__wrapper {
+    background-color: #0f172a;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+  }
+
+  .section-table {
+    color: #e2e8f0;
+  }
+
+  .section-table thead {
     background-color: #111827;
     color: #f8fafc;
   }
 
-  #lithology-table tbody tr:nth-child(even) {
-    background-color: #1f2937;
+  .section-table tbody tr:nth-child(even) {
+    background-color: rgba(30, 41, 59, 0.7);
   }
 
-  #lithology-table tbody tr:hover {
-    background-color: #0ea5e9;
-    color: #0f172a;
+  .section-table__empty {
+    color: #94a3b8;
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,19 +20,7 @@
         Loading lithology entries…
       </section>
 
-      <section class="table-wrapper" hidden>
-        <table id="lithology-table">
-          <thead>
-            <tr>
-              <th scope="col">Tab Name</th>
-              <th scope="col">Title</th>
-              <th scope="col">Description</th>
-              <th scope="col">PDF</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </section>
+      <section id="entries" class="entries" hidden></section>
     </main>
 
     <script src="{{ url_for('static', filename='app.js') }}" defer></script>


### PR DESCRIPTION
## Summary
- parse the geological workbook to attach lithological section tables to every PDF entry returned by the API
- redesign the front-end to render per-PDF cards and tables populated from the workbook data
- refresh the styling to support the new layout and provide dark-mode adjustments

## Testing
- python -m compileall app.py static/app.js

------
https://chatgpt.com/codex/tasks/task_e_68dfe9acddd883319511b60c7840a3a7