### PR TITLE
Update branding and filter lithology logs with data

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -67,7 +67,7 @@ body.with-cover header.site-nav {
 .nav-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 12px;
   min-height: var(--nav-h);
 }
@@ -299,6 +299,12 @@ body.with-cover .cover-hero {
   margin: 6px 0 0;
 }
 
+.library-note {
+  margin: 12px 0 0;
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+
 /* ---------- Status + entries ---------- */
 .status {
   margin: 0;
@@ -332,6 +338,7 @@ body.with-cover .cover-hero {
 .entries {
   display: grid;
   gap: clamp(18px, 2.4vw, 28px);
+  grid-template-columns: 1fr;
 }
 
 .entries[hidden] {
@@ -564,16 +571,6 @@ footer.site-footer {
   .btn.ghost {
     width: 100%;
     justify-content: center;
-  }
-
-  .entries {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (min-width: 721px) {
-  .entries {
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,11 +11,11 @@
       <div class="container">
         <div class="nav-row">
           <div class="brand-wrap">
-            <a class="brand-link" href="{{ url_for('index') }}">
+            <a class="brand-link" href="https://www.aiforimpact.net" target="_blank" rel="noopener noreferrer">
               <img
                 class="brand-logo"
-                src="https://cdn.jsdelivr.net/gh/ai-for-impact/brand@main/logo-square.png"
-                alt="Ai For Impact logo"
+                src="https://i.imgur.com/STm5VaG.png"
+                alt="Ai For Impact brand mark"
                 width="80"
                 height="80"
                 decoding="async"
@@ -25,13 +25,6 @@
               <span class="brand-text">Ai For Impact</span>
             </a>
           </div>
-
-          <nav class="nav-actions" aria-label="Pages">
-            <a class="nav-pill" href="{{ url_for('index') }}" data-active="true" aria-current="page">Home</a>
-            <a class="nav-pill" href="#library">Library</a>
-            <a class="nav-pill" href="#workflow">Workflow</a>
-            <a class="nav-pill" href="mailto:connect@aiforimpact.net">Contact</a>
-          </nav>
         </div>
       </div>
     </header>
@@ -64,6 +57,7 @@
           <p class="muted">
             PDF scans are automatically matched with interval tables from <em>Geological Profiles.xlsx</em>.
           </p>
+          <p class="library-note">To Nina Rman — Test by Hawkar Abdulhaq.</p>
         </div>
         <div class="body">
           <div class="card data-card">


### PR DESCRIPTION
## Summary
- update the header branding to use the provided logo and external link and add the requested dedication note
- enforce a single-column layout for log cards and refresh supporting styles
- filter out logs without interval data in the UI and adjust status messaging accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff14a2e50833196749da8dfde6949