### PR TITLE
Refactor lithology log rows

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -128,14 +128,8 @@ function createLithologyLog(sections) {
   const content = document.createElement('div');
   content.className = 'lithology-log__content';
 
-  const depthColumn = document.createElement('div');
-  depthColumn.className = 'lithology-log__depth';
-
-  const symbolColumn = document.createElement('div');
-  symbolColumn.className = 'lithology-log__column';
-
-  const descriptionColumn = document.createElement('div');
-  descriptionColumn.className = 'lithology-log__descriptions';
+  const rows = document.createElement('div');
+  rows.className = 'lithology-log__rows';
 
   const intervals = sections.map((section) => {
     const fromValue = parseDepthValue(section.from_depth);
@@ -154,49 +148,50 @@ function createLithologyLog(sections) {
   intervals.forEach((interval) => {
     const symbol = inferLithologySymbol(interval.description);
 
-    const depthItem = document.createElement('div');
-    depthItem.className = 'lithology-log__interval lithology-log__interval--depth';
-    depthItem.style.setProperty('--interval-size', interval.size / totalSize);
+    const row = document.createElement('div');
+    row.className = 'lithology-log__row';
+    row.style.setProperty('--interval-size', interval.size / totalSize);
+
+    const depthCell = document.createElement('div');
+    depthCell.className = 'lithology-log__cell lithology-log__cell--depth';
 
     const fromLabel = document.createElement('span');
     fromLabel.className = 'lithology-log__depth-value lithology-log__depth-value--from';
     fromLabel.textContent = formatDepth(interval.from_depth);
-    depthItem.appendChild(fromLabel);
+    depthCell.appendChild(fromLabel);
 
     const toLabel = document.createElement('span');
     toLabel.className = 'lithology-log__depth-value lithology-log__depth-value--to';
     toLabel.textContent = formatDepth(interval.to_depth);
-    depthItem.appendChild(toLabel);
+    depthCell.appendChild(toLabel);
 
-    depthColumn.appendChild(depthItem);
+    row.appendChild(depthCell);
 
-    const columnItem = document.createElement('div');
-    columnItem.className = 'lithology-log__interval lithology-log__interval--column';
-    columnItem.style.setProperty('--interval-size', interval.size / totalSize);
-    columnItem.style.setProperty('--symbol-color', symbol.color);
+    const symbolCell = document.createElement('div');
+    symbolCell.className = 'lithology-log__cell lithology-log__cell--symbol';
 
-    const columnLabel = document.createElement('span');
-    columnLabel.className = 'lithology-log__symbol-label';
-    columnLabel.textContent = symbol.label;
-    columnItem.appendChild(columnLabel);
+    const symbolLabel = document.createElement('span');
+    symbolLabel.className = 'lithology-log__symbol-label';
+    symbolLabel.textContent = symbol.label;
+    symbolLabel.style.setProperty('--symbol-color', symbol.color);
+    symbolCell.appendChild(symbolLabel);
 
-    symbolColumn.appendChild(columnItem);
+    row.appendChild(symbolCell);
 
-    const descriptionItem = document.createElement('div');
-    descriptionItem.className = 'lithology-log__interval lithology-log__interval--description';
-    descriptionItem.style.setProperty('--interval-size', interval.size / totalSize);
+    const descriptionCell = document.createElement('div');
+    descriptionCell.className = 'lithology-log__cell lithology-log__cell--description';
 
     const descriptionText = document.createElement('p');
     descriptionText.className = 'lithology-log__text';
     descriptionText.textContent = interval.description;
-    descriptionItem.appendChild(descriptionText);
+    descriptionCell.appendChild(descriptionText);
 
-    descriptionColumn.appendChild(descriptionItem);
+    row.appendChild(descriptionCell);
+
+    rows.appendChild(row);
   });
 
-  content.appendChild(depthColumn);
-  content.appendChild(symbolColumn);
-  content.appendChild(descriptionColumn);
+  content.appendChild(rows);
 
   wrapper.appendChild(header);
   wrapper.appendChild(content);

--- a/static/styles.css
+++ b/static/styles.css
@@ -450,41 +450,75 @@ body.with-cover .cover-hero {
 }
 
 .lithology-log__content {
+  display: flex;
+  flex-direction: column;
+  min-height: 320px;
+}
+
+.lithology-log__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: inherit;
+}
+
+.lithology-log__row {
+  --interval-size: 1;
+  position: relative;
   display: grid;
   grid-template-columns: minmax(120px, 160px) minmax(120px, 170px) 1fr;
   gap: 18px;
-  align-items: stretch;
-  min-height: 320px;
+  padding: 16px 18px;
+  border-radius: 14px;
+  background: rgba(6, 9, 16, 0.82);
+  border: 1px solid rgba(92, 169, 255, 0.14);
+  box-shadow: 0 16px 40px rgba(5, 10, 20, 0.24);
+  flex: var(--interval-size) 1 0;
+  overflow: hidden;
 }
 
-.lithology-log__depth,
-.lithology-log__column,
-.lithology-log__descriptions {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-height: 320px;
+.lithology-log__row::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+      to right,
+      rgba(92, 169, 255, 0.06),
+      transparent 32%,
+      transparent 68%,
+      rgba(92, 169, 255, 0.06)
+    );
+  opacity: 0.8;
+  pointer-events: none;
 }
 
-.lithology-log__interval {
-  --interval-size: 1;
+.lithology-log__row:nth-child(even) {
+  background: rgba(6, 12, 24, 0.82);
+}
+
+.lithology-log__row:nth-child(even)::after {
+  background: linear-gradient(
+      to right,
+      rgba(92, 169, 255, 0.1),
+      transparent 32%,
+      transparent 68%,
+      rgba(92, 169, 255, 0.1)
+    );
+}
+
+.lithology-log__cell {
   position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  flex: var(--interval-size) 1 0;
-  border-radius: 12px;
-  overflow: hidden;
-  background: rgba(6, 9, 16, 0.8);
-  border: 1px solid rgba(92, 169, 255, 0.14);
-  padding: 14px 16px;
+  gap: 8px;
 }
 
-.lithology-log__interval--depth {
+.lithology-log__cell--depth {
   justify-content: space-between;
   font-variant-numeric: tabular-nums;
   color: #d4dcf3;
-  background: rgba(6, 9, 16, 0.7);
 }
 
 .lithology-log__depth-value {
@@ -502,32 +536,17 @@ body.with-cover .cover-hero {
   color: rgba(226, 233, 255, 0.78);
 }
 
-.lithology-log__interval--column {
-  padding: 0;
-  justify-content: center;
+.lithology-log__cell--symbol {
   align-items: center;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.18);
-}
-
-.lithology-log__interval--column::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: var(--symbol-color, #6b7280);
-  opacity: 0.82;
 }
 
 .lithology-log__symbol-label {
   position: relative;
-  z-index: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 8px 14px;
+  padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(6, 9, 16, 0.82);
   color: #f4f6ff;
   font-size: 13px;
   font-weight: 700;
@@ -536,9 +555,22 @@ body.with-cover .cover-hero {
   box-shadow: 0 18px 40px rgba(5, 10, 20, 0.38);
 }
 
-.lithology-log__interval--description {
+.lithology-log__symbol-label::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(--symbol-color, #6b7280);
+  opacity: 0.82;
+  z-index: -1;
+}
+
+.lithology-log__cell--description {
   align-items: flex-start;
-  background: rgba(6, 9, 16, 0.82);
+  background: rgba(6, 9, 16, 0.75);
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(92, 169, 255, 0.12);
 }
 
 .lithology-log__text {
@@ -549,19 +581,27 @@ body.with-cover .cover-hero {
 }
 
 @media (max-width: 780px) {
-  .lithology-log__header,
-  .lithology-log__content {
+  .lithology-log__header {
     grid-template-columns: 1fr;
+    gap: 6px;
   }
 
   .lithology-log__content {
     min-height: auto;
   }
 
-  .lithology-log__depth,
-  .lithology-log__column,
-  .lithology-log__descriptions {
-    min-height: auto;
+  .lithology-log__rows {
+    gap: 10px;
+  }
+
+  .lithology-log__row {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    padding: 14px;
+  }
+
+  .lithology-log__cell--description {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- render each lithology interval as a dedicated row that groups depth, symbol, and description
- restyle the log to support the row layout with zebra striping and responsive tweaks

## Testing
- python app.py

------
https://chatgpt.com/codex/tasks/task_e_68dff8fcb03883318abdf1e75e1d9576